### PR TITLE
add property in Manifest so ScrollView works as expected

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,7 +56,8 @@
 
         <activity
             android:name=".AuthActivity"
-            android:label="@string/app_title">
+            android:label="@string/app_title"
+            android:windowSoftInputMode="adjustResize">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
When you select email text box in login screen, Scroll is not enabled even if the keyboard is deployed. 
Solution:
Add android:windowSoftInputMode="adjustResize" in Manifest.
See https://developer.android.com/training/keyboard-input/visibility#Respond